### PR TITLE
Improve log readability

### DIFF
--- a/src/pruner.py
+++ b/src/pruner.py
@@ -238,7 +238,7 @@ def select_tags_to_remove(organization,repository,tags, parameter, current_ts):
     elif 'keep_tags_younger_than' in parameter.keys() and 'keep_n_tags' not in parameter.keys():
         result=tag_deleted_by_keep_tags_younger_than
 
-    logger.info(f"The tags of the organization '{organization}' and repository '{repository}' that can be deleted "
+    logger.debug(f"The tags of the organization '{organization}' and repository '{repository}' that can be deleted "
                 f"based on all the parameters '{parameter}' are: "
                 f"{json.dumps( prettify_tag_list_of_dict(result),indent=4 )}")
     return result
@@ -269,7 +269,7 @@ def delete_tags(quay_host, app_token, quay_org, image, tags):
                     f"{quay_org}/{image}:{tag['name']} has already been deleted"
                 )
             else:
-                logger.exception(f"Error deleting tag {tag['name']}: {err}")
+                logger.exception(f"Error deleting tag {tag['name']} of the image {quay_org}/{image}: {err}")
         else:
             logger.info(f"{quay_org}/{image}:{tag['name']} deleted")
 
@@ -313,11 +313,11 @@ def apply_pruner_rule(
                 continue
 
             if dry_run:
-                logger.info(
-                    f"DRY-RUN Candidate tags for deletion "
-                    f"for image {image['name']}: "
-                    f"{json.dumps( prettify_tag_list_of_dict(bad_tags) , indent=4) }"
-                )
+                for tag in prettify_tag_list_of_dict(bad_tags):
+                    logger.info( f"DRY-RUN Candidate tags for deletion "
+                                 f"for image {organization} / {image['name']}:{tag['name']}"
+                                 f"\t\tlast_modified: {tag['last_modified']} \tstart_ts: {tag['start_ts']}"
+                                 )
             else:
                 delete_tags(quay_host, app_token, organization,
                             image["name"], bad_tags)


### PR DESCRIPTION
1.  Move message log "The tags of the organization '{organization}' and repository '{repository}' that can be deleted " of function select_tags_to_remove from level "info" to "debug". The same information is reported with level info in the following logs from other function (DRY-RUN or deleted tags)

2. When there is an error during the deletion of a tag, the name of the organization and image of the tag has been added in the exception message

3. Print the "DRY-RUN Candidate tags for deletion one tag for each line including the information about organization name, repository name, tag name, last_modified and timestamp attribute". This allow to grep the output of the script using the string "DRY-RUN" to extract all the tags that would be removed during the dry-run