### PR TITLE
Fix typo in configuration file name in the configmap

### DIFF
--- a/helm/pruner/templates/configmap.yaml
+++ b/helm/pruner/templates/configmap.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 data:
-  config.json: |-
+  config.yaml: |-
 {{ .Files.Get "config.yaml" | nindent 4 }}
 kind: ConfigMap
 metadata:


### PR DESCRIPTION
Rename from config.json to config.yaml